### PR TITLE
Add client-side encryption support (SDK 1.2.6)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,21 @@ PRIVATE_KEY=your_private_key_here
 # Optional: Retry configuration
 # MAX_RETRIES=3
 # MAX_GAS_PRICE=3000000000000
+
+# -----------------------------------------------------------------------------
+# Optional: Client-side encryption (SDK >= 1.2.2)
+# -----------------------------------------------------------------------------
+# Encrypts files on upload. Same key is needed to decrypt on download.
+# If you lose the key the data is unrecoverable.
+#
+# Mode 1 — aes256 (symmetric). One 32-byte key for encrypt + decrypt.
+# ENCRYPTION_MODE=aes256
+# ENCRYPTION_KEY=0x<64 hex chars>
+#
+# Mode 2 — ecies (asymmetric secp256k1). Encrypt to a recipient public key.
+# ENCRYPTION_MODE=ecies
+# RECIPIENT_PUBKEY=0x<compressed 33-byte pubkey hex>
+#
+# For downloads of encrypted files — supply the matching key:
+# DECRYPTION_KEY=0x<64 hex chars>       # aes256
+# RECIPIENT_PRIVKEY=0x<privkey hex>     # ecies (can reuse PRIVATE_KEY)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A developer-friendly starter kit for [0G Storage](https://docs.0g.ai) — decentralized storage on the 0G network. Upload and download files using scripts, import as a library, or run the web UI with MetaMask.
 
-**SDK**: `@0gfoundation/0g-ts-sdk` v1.2.1 | **Networks**: Testnet (Galileo) & Mainnet | **Modes**: Turbo & Standard
+**SDK**: `@0gfoundation/0g-ts-sdk` v1.2.6 | **Networks**: Testnet (Galileo) & Mainnet | **Modes**: Turbo & Standard | **Encryption**: AES-256 + ECIES
 
 ---
 
@@ -53,6 +53,17 @@ npm run upload:data -- -f ./data.bin
 
 # Upload multiple files
 npm run upload:batch -- file1.txt file2.txt file3.txt
+
+# Encrypted upload (see "Encryption" below for details)
+npm run upload:encrypted -- ./file.txt --mode aes256
+npm run upload:encrypted -- ./file.txt --mode ecies
+
+# Peek a file's encryption header (no full download)
+npm run peek -- 0xabc123...
+
+# Encrypted download
+npm run download:encrypted -- 0xabc123... --key 0x<hex>       # aes256
+npm run download:encrypted -- 0xabc123... --privkey 0x<hex>   # ecies
 
 # Run all integration tests
 npm run test:all
@@ -125,13 +136,127 @@ const results = await batchUpload(['a.txt', 'b.txt'], config);
 
 | Function | Description |
 |----------|-------------|
-| `uploadFile(path, config)` | Upload a file from filesystem |
-| `downloadFile(rootHash, outputPath, config)` | Download by root hash |
-| `uploadData(data, config)` | Upload string or Uint8Array via MemData |
+| `uploadFile(path, config)` | Upload a file from filesystem (honors `config.encryption`) |
+| `downloadFile(rootHash, outputPath, config)` | Download by root hash (honors `config.decryption`) |
+| `uploadData(data, config)` | Upload string or Uint8Array via MemData (honors `config.encryption`) |
 | `batchUpload(paths[], config)` | Upload multiple files sequentially |
-| `getConfig(overrides?)` | Load config from .env with optional overrides (`network`, `mode`, `privateKey`) |
+| `peekHeader(rootHash, config)` | Peek the encryption header without downloading body |
+| `getConfig(overrides?)` | Load config from .env with optional overrides (`network`, `mode`, `privateKey`, `encryption`, `decryption`) |
+| `generateAes256Key()` | Generate a random 32-byte AES-256 key |
+| `pubKeyFromPrivateKey(priv)` | Derive compressed secp256k1 pubkey (for ECIES encrypt-to-self) |
+| `hexToBytes(hex)` | Parse a 0x-prefixed or bare hex string |
 | `createSigner(config)` | Create ethers.js wallet signer |
 | `createIndexer(config)` | Create 0G Indexer client |
+
+---
+
+## Encryption
+
+SDK 1.2.2+ supports **client-side encryption** with two modes. The encryption
+happens in the SDK before upload, and files stored encrypted carry a short
+header (17 bytes for aes256, 50 for ecies) that lets the reader auto-detect
+the mode. The 0G storage network never sees plaintext.
+
+| Mode | Key model | When to use |
+|------|-----------|-------------|
+| `aes256` | One 32-byte symmetric key | Backups, single-user data, sharing via a pre-shared key |
+| `ecies`  | secp256k1 keypair (reuses wallet keys) | Encrypt-to-recipient without pre-sharing a secret |
+
+> **Warning:** lose the key and the data is unrecoverable. 0G can't help — encryption is client-side.
+
+### Script recipes
+
+**Without encryption** (plain upload/download):
+```bash
+npm run upload   -- ./file.txt
+npm run download -- 0x<rootHash> --output ./out.txt
+```
+
+**AES-256 symmetric** (simplest — one key, encrypt and decrypt):
+```bash
+# Upload — if --key is omitted, a random key is generated and printed.
+npm run upload:encrypted -- ./secret.txt --mode aes256
+# -> Root Hash: 0xabc...
+# -> Decryption key (symmetric): 0xdeadbeef...  <-- save this!
+
+# Download + decrypt with the same key.
+npm run download:encrypted -- 0xabc... --key 0xdeadbeef...
+```
+
+**ECIES asymmetric** (encrypt to a recipient's pubkey; they decrypt with their privkey):
+```bash
+# Encrypt to yourself (uses your PRIVATE_KEY to derive the pubkey).
+npm run upload:encrypted -- ./secret.txt --mode ecies
+
+# Encrypt to someone else's pubkey.
+npm run upload:encrypted -- ./secret.txt --mode ecies --recipient 0x02abc...
+
+# Download + decrypt with the matching private key.
+npm run download:encrypted -- 0xroot... --privkey 0xPRIVATE_KEY
+```
+
+**Peek before downloading** (useful for UIs that prompt for a key):
+```bash
+npm run peek -- 0xabc...
+# Encryption header detected:
+#   Type:        aes256 (symmetric, v1)
+#   Header size: 17 bytes
+#   Nonce:       0x...
+```
+
+### Library usage
+
+```typescript
+import {
+  uploadFile, downloadFile, peekHeader,
+  getConfig, generateAes256Key, pubKeyFromPrivateKey,
+} from './src/index.js';
+
+// aes256 round-trip
+const key = generateAes256Key();
+const upCfg = getConfig({ encryption: { type: 'aes256', key } });
+const { rootHash } = await uploadFile('./secret.txt', upCfg);
+
+const dlCfg = getConfig({ decryption: { symmetricKey: key } });
+await downloadFile(rootHash, './out.txt', dlCfg);
+
+// ECIES — encrypt to a recipient's pubkey
+const recipientPub = pubKeyFromPrivateKey(someWalletPriv);
+const eciesCfg = getConfig({ encryption: { type: 'ecies', recipientPubKey: recipientPub } });
+await uploadFile('./secret.txt', eciesCfg);
+
+// Peek before deciding how to decrypt
+const header = await peekHeader(rootHash, getConfig());
+if (header?.version === 1)      console.log('aes256');
+else if (header?.version === 2) console.log('ecies');
+else                            console.log('plaintext');
+```
+
+### Env-var configuration
+
+Set these in `.env` to make every upload/download encrypt/decrypt by default:
+
+```env
+# aes256 path
+ENCRYPTION_MODE=aes256
+ENCRYPTION_KEY=0x<64 hex chars>
+DECRYPTION_KEY=0x<64 hex chars>
+
+# ecies path
+ENCRYPTION_MODE=ecies
+RECIPIENT_PUBKEY=0x<33-byte compressed pubkey hex>
+RECIPIENT_PRIVKEY=0x<privkey>   # or reuse PRIVATE_KEY
+```
+
+### Notes & gotchas
+
+- **`indexer.download()` has no decryption option.** When `config.decryption` is
+  set, this kit routes through `indexer.downloadToBlob({ decryption })` and
+  writes the Blob to disk. Large files on the plain path still stream.
+- **Best-effort decrypt**: the SDK silently returns raw bytes if the key is
+  wrong or the file isn't encrypted. Call `peekHeader` first to distinguish.
+- **ECIES reuses your wallet key.** Both 0G storage signing and ECIES use
+  secp256k1, so a single private key works for both.
 
 ---
 
@@ -149,11 +274,14 @@ const results = await batchUpload(['a.txt', 'b.txt'], config);
     index.ts                # Barrel re-exports
 
   scripts/                  # Runnable entry points (all support --network, --mode, --key)
-    upload.ts               # File upload script
-    download.ts             # File download script
+    upload.ts               # Plain file upload
+    download.ts             # Plain file download
     upload-data.ts          # String/buffer upload (MemData)
     batch-upload.ts         # Multi-file upload
-    test-all.ts             # Integration test suite
+    encrypted-upload.ts     # Upload with aes256 or ecies encryption
+    encrypted-download.ts   # Download + decrypt (auto-peeks header)
+    peek-header.ts          # Inspect encryption header without full download
+    test-all.ts             # Integration test suite (plain + encrypted)
 
   web/                      # Optional: Browser UI
     index.html              # Single-page app

--- a/README.md
+++ b/README.md
@@ -152,17 +152,16 @@ const results = await batchUpload(['a.txt', 'b.txt'], config);
 
 ## Encryption
 
-SDK 1.2.2+ supports **client-side encryption** with two modes. The encryption
-happens in the SDK before upload, and files stored encrypted carry a short
-header (17 bytes for aes256, 50 for ecies) that lets the reader auto-detect
-the mode. The 0G storage network never sees plaintext.
+SDK 1.2.6+ supports **client-side encryption** with two modes. Files are encrypted before upload — the 0G network never sees plaintext. A compact header prepended to each file lets the SDK auto-detect the mode on download.
 
-| Mode | Key model | When to use |
-|------|-----------|-------------|
-| `aes256` | One 32-byte symmetric key | Backups, single-user data, sharing via a pre-shared key |
-| `ecies`  | secp256k1 keypair (reuses wallet keys) | Encrypt-to-recipient without pre-sharing a secret |
+| Mode | Key material | Header size | Wire format |
+|------|-------------|-------------|-------------|
+| `aes256` | 32-byte symmetric key | 17 bytes | `[v=0x01][nonce:16]` |
+| `ecies`  | secp256k1 keypair | 50 bytes | `[v=0x02][ephemeralPub:33][nonce:16]` |
 
-> **Warning:** lose the key and the data is unrecoverable. 0G can't help — encryption is client-side.
+> **Warning:** lose the key and the data is unrecoverable. 0G can't help — encryption is entirely client-side.
+
+**Go/TypeScript interoperability**: both SDKs share the same wire format and HKDF parameters. A file encrypted in Go can be decrypted in TypeScript and vice versa.
 
 ### Script recipes
 
@@ -204,7 +203,7 @@ npm run peek -- 0xabc...
 #   Nonce:       0x...
 ```
 
-### Library usage
+### Library usage (starter kit wrappers)
 
 ```typescript
 import {
@@ -212,24 +211,89 @@ import {
   getConfig, generateAes256Key, pubKeyFromPrivateKey,
 } from './src/index.js';
 
-// aes256 round-trip
+// AES-256 round-trip
 const key = generateAes256Key();
-const upCfg = getConfig({ encryption: { type: 'aes256', key } });
-const { rootHash } = await uploadFile('./secret.txt', upCfg);
-
-const dlCfg = getConfig({ decryption: { symmetricKey: key } });
-await downloadFile(rootHash, './out.txt', dlCfg);
+const { rootHash } = await uploadFile('./secret.txt', getConfig({
+  encryption: { type: 'aes256', key },
+}));
+await downloadFile(rootHash, './out.txt', getConfig({
+  decryption: { symmetricKey: key },
+}));
 
 // ECIES — encrypt to a recipient's pubkey
-const recipientPub = pubKeyFromPrivateKey(someWalletPriv);
-const eciesCfg = getConfig({ encryption: { type: 'ecies', recipientPubKey: recipientPub } });
-await uploadFile('./secret.txt', eciesCfg);
+const recipientPubKey = pubKeyFromPrivateKey(someWalletPrivKey);
+const { rootHash: hash } = await uploadFile('./secret.txt', getConfig({
+  encryption: { type: 'ecies', recipientPubKey },
+}));
+await downloadFile(hash, './out.txt', getConfig({
+  decryption: { privateKey: someWalletPrivKey },
+}));
 
 // Peek before deciding how to decrypt
 const header = await peekHeader(rootHash, getConfig());
-if (header?.version === 1)      console.log('aes256');
-else if (header?.version === 2) console.log('ecies');
-else                            console.log('plaintext');
+// header === null  → plaintext
+// header.version === 1 → aes256
+// header.version === 2 → ecies
+```
+
+### Direct SDK usage
+
+The starter kit wrappers call these SDK interfaces internally. Use them directly when you need full control:
+
+```typescript
+import { ZgFile, Indexer } from '@0gfoundation/0g-ts-sdk';
+import type { UploadOption, DownloadOption } from '@0gfoundation/0g-ts-sdk';
+import { ethers } from 'ethers';
+
+const indexer = new Indexer(indexerRpc);
+const signer = new ethers.Wallet(privateKey, provider);
+
+// Key generation — SDK has no utility; use Web Crypto (works in Node 18+ and browser)
+const key = new Uint8Array(32);
+crypto.getRandomValues(key);
+
+// AES-256 upload
+const [tx, upErr] = await indexer.upload(
+  await ZgFile.fromFilePath('./secret.txt'),
+  rpcUrl,
+  signer,
+  { encryption: { type: 'aes256', key } } satisfies UploadOption,
+);
+
+// AES-256 download + decrypt — returns [Blob, Error | null]
+const [blob, dlErr] = await indexer.downloadToBlob(rootHash, {
+  proof: true,
+  decryption: { symmetricKey: key },
+} satisfies DownloadOption);
+
+// ECIES — derive pubkey from wallet (encrypt-to-self)
+const recipientPubKey = ethers.SigningKey.computePublicKey(
+  signer.signingKey.publicKey, true, // compressed 33-byte key
+);
+const [tx2, _] = await indexer.upload(file, rpcUrl, signer, {
+  encryption: { type: 'ecies', recipientPubKey },
+});
+const [blob2, __] = await indexer.downloadToBlob(rootHash, {
+  decryption: { privateKey }, // 0x-prefixed hex or Uint8Array
+});
+
+// Peek header — returns [EncryptionHeader | null, Error | null]
+const [header, peekErr] = await indexer.peekHeader(rootHash);
+// null = plaintext | header.version 1 = aes256 | header.version 2 = ecies
+
+// Multi-fragment encrypted file — same function, array overload
+const rootHashes = [fragment0Hash, fragment1Hash]; // roots from a fragmented upload
+const [combinedBlob, err] = await indexer.downloadToBlob(rootHashes, {
+  decryption: { symmetricKey: key },
+});
+```
+
+> **`indexer.download()` does not support decryption.** It writes directly to disk via `fs` and has no decryption hook. Always use `indexer.downloadToBlob()` for encrypted files.
+
+Run the SDK-level test to validate all patterns against the live network:
+
+```bash
+npm run test:sdk-encryption
 ```
 
 ### Env-var configuration

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "0g-storage-ts-starter",
       "version": "2.0.0",
       "dependencies": {
-        "@0gfoundation/0g-ts-sdk": "^1.2.1",
+        "@0gfoundation/0g-ts-sdk": "^1.2.6",
         "commander": "^11.1.0",
         "dotenv": "^16.3.1",
         "ethers": "^6.13.1"
@@ -17,20 +17,53 @@
         "@types/node": "^20.11.0",
         "tsx": "^4.7.0",
         "typescript": "^5.3.3"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@0gfoundation/0g-ts-sdk": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@0gfoundation/0g-ts-sdk/-/0g-ts-sdk-1.2.1.tgz",
-      "integrity": "sha512-1PBq+aug6p3OYh9UbEDxn+mroQ4XCjd7355wwStfd8ykyKMXHTdrSuNrfranr5TnF/uksKUWnN3HJ73gYKKDpw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@0gfoundation/0g-ts-sdk/-/0g-ts-sdk-1.2.6.tgz",
+      "integrity": "sha512-1CXUnMblQOVJek+T7l+DRn1KuzPmZV6JfMrZbXOihSAPF2er8vFkq519MqoJroUH2yEjdW1z41x5aVPbCSp1gQ==",
       "license": "ISC",
       "dependencies": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/keccak256": "^5.7.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "^1.9.7",
+        "@noble/hashes": "^1.8.0",
         "open-jsonrpc-provider": "^0.2.1"
       },
       "peerDependencies": {
         "ethers": "6.13.1"
+      }
+    },
+    "node_modules/@0gfoundation/0g-ts-sdk/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@0gfoundation/0g-ts-sdk/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@adraffy/ens-normalize": {
@@ -531,6 +564,18 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ]
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@noble/curves": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "download": "tsx scripts/download.ts",
     "upload:data": "tsx scripts/upload-data.ts",
     "upload:batch": "tsx scripts/batch-upload.ts",
+    "upload:encrypted": "tsx scripts/encrypted-upload.ts",
+    "download:encrypted": "tsx scripts/encrypted-download.ts",
+    "peek": "tsx scripts/peek-header.ts",
     "test:all": "tsx scripts/test-all.ts",
     "web": "cd web && npm run dev",
     "web:build": "cd web && npm run build",
@@ -23,7 +26,7 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@0gfoundation/0g-ts-sdk": "^1.2.1",
+    "@0gfoundation/0g-ts-sdk": "^1.2.6",
     "commander": "^11.1.0",
     "dotenv": "^16.3.1",
     "ethers": "^6.13.1"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "download:encrypted": "tsx scripts/encrypted-download.ts",
     "peek": "tsx scripts/peek-header.ts",
     "test:all": "tsx scripts/test-all.ts",
+    "test:sdk-encryption": "tsx scripts/test-sdk-encryption.ts",
     "web": "cd web && npm run dev",
     "web:build": "cd web && npm run build",
     "build": "tsc",

--- a/scripts/encrypted-download.ts
+++ b/scripts/encrypted-download.ts
@@ -1,0 +1,93 @@
+/**
+ * Encrypted file download example.
+ *
+ * Peeks the encryption header first so the user sees whether the file is
+ * aes256 or ecies before committing to a full download, then decrypts via
+ * `indexer.downloadToBlob({ decryption })`.
+ *
+ * Usage:
+ *   npm run download:encrypted -- 0x<rootHash> --key 0x<32-byte hex>      # aes256
+ *   npm run download:encrypted -- 0x<rootHash> --privkey 0x<privkey>       # ecies
+ *   npm run download:encrypted -- 0x<rootHash> --privkey $PRIVATE_KEY      # encrypted to self
+ */
+import 'dotenv/config';
+import { Command } from 'commander';
+import path from 'path';
+import {
+  downloadFile,
+  peekHeader,
+  getConfig,
+  type DecryptionConfig,
+} from '../src/index.js';
+
+const program = new Command();
+
+program
+  .name('encrypted-download')
+  .description('Download and decrypt a file from 0G Storage')
+  .argument('<roothash>', 'Root hash of the file to download')
+  .option('--key <hex>', 'aes256: 32-byte symmetric hex key')
+  .option('--privkey <hex>', 'ecies: your secp256k1 private key')
+  .option('-n, --network <name>', 'Network: testnet or mainnet')
+  .option('-m, --mode <mode>', 'Storage mode: turbo or standard (default: turbo)')
+  .option('-o, --output <path>', 'Output file path (default: ./downloads/<roothash>)')
+  .action(async (roothash: string, opts) => {
+    try {
+      const config = getConfig({ network: opts.network, mode: opts.mode });
+
+      console.log(`Peeking header on ${config.network.name} (${config.network.mode})...`);
+      const header = await peekHeader(roothash, config);
+
+      if (header === null) {
+        console.warn(
+          '! No encryption header detected. The file is either plaintext or uses\n' +
+          '  an unknown format. Falling back to plain download.\n',
+        );
+      } else {
+        const kind = header.version === 1 ? 'aes256 (v1)' : `ecies (v${header.version})`;
+        console.log(`Detected header: ${kind}, ${header.size()} bytes`);
+      }
+
+      const decryption = buildDecryption(opts, header?.version);
+      if (decryption) config.decryption = decryption;
+
+      const outputPath = opts.output || path.join('downloads', roothash);
+      console.log(`Downloading to: ${outputPath}`);
+
+      const result = await downloadFile(roothash, outputPath, config);
+
+      console.log('\nDownload successful!');
+      console.log('Saved to:', result.outputPath);
+      if (header !== null && !decryption) {
+        console.warn(
+          '! File was encrypted but no key was supplied. Raw ciphertext saved.\n' +
+          '  Re-run with --key (aes256) or --privkey (ecies) to decrypt.',
+        );
+      }
+    } catch (err) {
+      console.error('Error:', err instanceof Error ? err.message : err);
+      process.exit(1);
+    }
+  });
+
+program.parse();
+
+function buildDecryption(
+  opts: { key?: string; privkey?: string },
+  headerVersion: number | undefined,
+): DecryptionConfig | undefined {
+  if (!opts.key && !opts.privkey) return undefined;
+
+  const d: DecryptionConfig = {};
+  if (opts.key) d.symmetricKey = opts.key;
+  if (opts.privkey) d.privateKey = opts.privkey;
+
+  // Friendly warnings when key type doesn't match the detected header.
+  if (headerVersion === 1 && opts.privkey && !opts.key) {
+    console.warn('! Header is aes256 (v1) but only --privkey was supplied; pass --key instead.');
+  }
+  if (headerVersion === 2 && opts.key && !opts.privkey) {
+    console.warn('! Header is ecies (v2) but only --key was supplied; pass --privkey instead.');
+  }
+  return d;
+}

--- a/scripts/encrypted-upload.ts
+++ b/scripts/encrypted-upload.ts
@@ -1,0 +1,132 @@
+/**
+ * Encrypted file upload example.
+ *
+ * Demonstrates the two encryption modes introduced in @0gfoundation/0g-ts-sdk
+ * 1.2.2+:
+ *   - aes256 (symmetric): one 32-byte key encrypts and decrypts.
+ *   - ecies  (asymmetric): encrypt to a recipient's secp256k1 pubkey; decrypt
+ *     with the matching private key.
+ *
+ * Usage:
+ *   npm run upload:encrypted -- ./file.txt --mode aes256
+ *   npm run upload:encrypted -- ./file.txt --mode aes256 --key 0x<64 hex>
+ *   npm run upload:encrypted -- ./file.txt --mode ecies  --recipient 0x<compressed pubkey>
+ *   npm run upload:encrypted -- ./file.txt --mode ecies   # encrypt to self (uses PRIVATE_KEY)
+ */
+import 'dotenv/config';
+import { Command } from 'commander';
+import { ethers } from 'ethers';
+import {
+  uploadFile,
+  getConfig,
+  generateAes256Key,
+  hexToBytes,
+  pubKeyFromPrivateKey,
+  type EncryptionConfig,
+} from '../src/index.js';
+
+const program = new Command();
+
+program
+  .name('encrypted-upload')
+  .description('Upload an encrypted file to 0G Storage')
+  .argument('<filepath>', 'Path to the file to upload')
+  .requiredOption('--mode <mode>', 'Encryption mode: aes256 or ecies')
+  .option('--key <hex>', 'aes256: 32-byte hex key (auto-generated if omitted)')
+  .option('--recipient <hex>', 'ecies: recipient compressed secp256k1 pubkey (defaults to self)')
+  .option('-n, --network <name>', 'Network: testnet or mainnet')
+  .option('-m, --storage-mode <mode>', 'Storage mode: turbo or standard (default: turbo)')
+  .option('-k, --signer-key <key>', 'Private key for signing the storage tx')
+  .action(async (filepath: string, opts) => {
+    try {
+      const config = getConfig({
+        network: opts.network,
+        mode: opts.storageMode,
+        privateKey: opts.signerKey,
+      });
+
+      const encryption = buildEncryption(opts, config.privateKey);
+      config.encryption = encryption;
+
+      printPlan(filepath, config.network.name, config.network.mode, encryption);
+
+      const result = await uploadFile(filepath, config);
+
+      console.log('\nUpload successful!');
+      console.log('Root Hash:', result.rootHash);
+      console.log('Tx Hash: ', result.txHash);
+      console.log(`Explorer:  ${config.network.explorerUrl}/tx/${result.txHash}`);
+
+      console.log('\n--- SAVE THIS TO DECRYPT LATER ---');
+      if (encryption.type === 'aes256') {
+        console.log('Decryption key (symmetric):');
+        console.log(`  ${toHex(encryption.key)}`);
+        console.log('\nDownload with:');
+        console.log(
+          `  npm run download:encrypted -- ${result.rootHash} --key ${toHex(encryption.key)}`,
+        );
+      } else {
+        console.log('Encrypted with ECIES to recipient pubkey:');
+        console.log(`  ${encryption.recipientPubKey}`);
+        console.log('\nDownload with the matching private key:');
+        console.log(
+          `  npm run download:encrypted -- ${result.rootHash} --privkey <private_key>`,
+        );
+      }
+    } catch (err) {
+      console.error('Error:', err instanceof Error ? err.message : err);
+      process.exit(1);
+    }
+  });
+
+program.parse();
+
+function buildEncryption(
+  opts: { mode: string; key?: string; recipient?: string },
+  signerKey: string | undefined,
+): EncryptionConfig {
+  if (opts.mode === 'aes256') {
+    const key = opts.key ? hexToBytes(opts.key) : generateAes256Key();
+    if (key.length !== 32) {
+      throw new Error(`aes256 key must be 32 bytes (64 hex chars), got ${key.length}`);
+    }
+    if (!opts.key) {
+      console.warn('! No --key provided; generated a random 32-byte key.');
+      console.warn('! You MUST save the key printed below or the file is unrecoverable.\n');
+    }
+    return { type: 'aes256', key };
+  }
+  if (opts.mode === 'ecies') {
+    let recipient = opts.recipient;
+    if (!recipient) {
+      if (!signerKey) {
+        throw new Error(
+          'ecies without --recipient needs a signer private key (PRIVATE_KEY or --signer-key) to encrypt-to-self',
+        );
+      }
+      recipient = pubKeyFromPrivateKey(signerKey);
+      console.warn(`! No --recipient provided; encrypting to self: ${recipient}\n`);
+    }
+    return { type: 'ecies', recipientPubKey: recipient };
+  }
+  throw new Error(`Invalid --mode: "${opts.mode}". Use "aes256" or "ecies".`);
+}
+
+function printPlan(
+  filepath: string,
+  network: string,
+  storageMode: string,
+  enc: EncryptionConfig,
+): void {
+  console.log('='.repeat(60));
+  console.log('Encrypted Upload');
+  console.log('='.repeat(60));
+  console.log(`File:     ${filepath}`);
+  console.log(`Network:  ${network} (${storageMode})`);
+  console.log(`Encrypt:  ${enc.type}`);
+  console.log('='.repeat(60));
+}
+
+function toHex(bytes: Uint8Array): string {
+  return '0x' + ethers.hexlify(bytes).slice(2);
+}

--- a/scripts/peek-header.ts
+++ b/scripts/peek-header.ts
@@ -1,0 +1,50 @@
+/**
+ * Peek at a stored file's encryption header without downloading the body.
+ *
+ * Useful to know whether a root hash points to encrypted content (and which
+ * mode) before prompting the user for a key.
+ *
+ * Usage:
+ *   npm run peek -- 0x<rootHash>
+ */
+import 'dotenv/config';
+import { Command } from 'commander';
+import { ethers } from 'ethers';
+import { peekHeader, getConfig } from '../src/index.js';
+
+const program = new Command();
+
+program
+  .name('peek')
+  .description('Peek the encryption header of a file by root hash')
+  .argument('<roothash>', 'Root hash of the file')
+  .option('-n, --network <name>', 'Network: testnet or mainnet')
+  .option('-m, --mode <mode>', 'Storage mode: turbo or standard (default: turbo)')
+  .action(async (roothash: string, opts) => {
+    try {
+      const config = getConfig({ network: opts.network, mode: opts.mode });
+      const header = await peekHeader(roothash, config);
+
+      if (header === null) {
+        console.log('No encryption header. File is plaintext (or header malformed).');
+        return;
+      }
+
+      const kind = header.version === 1 ? 'aes256 (symmetric, v1)'
+        : header.version === 2 ? 'ecies (asymmetric, v2)'
+        : `unknown (v${header.version})`;
+
+      console.log('Encryption header detected:');
+      console.log(`  Type:          ${kind}`);
+      console.log(`  Header size:   ${header.size()} bytes`);
+      console.log(`  Nonce:         ${ethers.hexlify(header.nonce)}`);
+      if (header.version === 2) {
+        console.log(`  Ephemeral pub: ${ethers.hexlify(header.ephemeralPub)}`);
+      }
+    } catch (err) {
+      console.error('Error:', err instanceof Error ? err.message : err);
+      process.exit(1);
+    }
+  });
+
+program.parse();

--- a/scripts/test-all.ts
+++ b/scripts/test-all.ts
@@ -60,11 +60,12 @@ async function test(name: string, fn: () => Promise<void>) {
 let uploadedRootHash = '';
 
 await test('uploadFile - upload test-file.txt', async () => {
-  const testFile = path.join('test-uploads', 'test-file.txt');
-  if (!fs.existsSync(testFile)) {
-    fs.mkdirSync('test-uploads', { recursive: true });
-    fs.writeFileSync(testFile, `0G Storage test - ${new Date().toISOString()}`);
-  }
+  // Always write fresh content so the root hash is new on every run.
+  // Reusing a static file triggers skipIfFinalized, which returns txHash:''
+  // and breaks the test even though the upload "succeeded".
+  fs.mkdirSync('test-uploads', { recursive: true });
+  const testFile = path.join('test-uploads', `test-file-${Date.now()}.txt`);
+  fs.writeFileSync(testFile, `0G Storage test - ${new Date().toISOString()}`);
 
   const result = await uploadFile(testFile, config);
   console.log(`  Root Hash: ${result.rootHash}`);

--- a/scripts/test-all.ts
+++ b/scripts/test-all.ts
@@ -8,7 +8,16 @@
 import 'dotenv/config';
 import fs from 'fs';
 import path from 'path';
-import { getConfig, uploadFile, downloadFile, uploadData, batchUpload } from '../src/index.js';
+import {
+  getConfig,
+  uploadFile,
+  downloadFile,
+  uploadData,
+  batchUpload,
+  peekHeader,
+  generateAes256Key,
+  pubKeyFromPrivateKey,
+} from '../src/index.js';
 
 const networkArg = process.argv.indexOf('--network');
 const network = networkArg !== -1 ? process.argv[networkArg + 1] : undefined;
@@ -160,6 +169,76 @@ await test('uploadData - handles empty data gracefully', async () => {
     } else {
       throw err;
     }
+  }
+});
+
+// --- Test 7: Encrypted upload/download — aes256 round-trip ---
+await test('encrypted (aes256) - upload then download with symmetric key', async () => {
+  const plaintext = `aes256 round-trip - ${new Date().toISOString()}`;
+  const file = path.join('test-uploads', 'enc-aes256.txt');
+  fs.writeFileSync(file, plaintext);
+
+  const key = generateAes256Key();
+  const encConfig = { ...config, encryption: { type: 'aes256' as const, key } };
+  const uploaded = await uploadFile(file, encConfig);
+  console.log(`  Root Hash: ${uploaded.rootHash}`);
+
+  const header = await peekHeader(uploaded.rootHash, config);
+  if (header?.version !== 1) {
+    throw new Error(`Expected header v1 (aes256), got ${header?.version ?? 'none'}`);
+  }
+  console.log('  peekHeader detected aes256 (v1)');
+
+  const out = path.join('downloads', `enc-aes256-${Date.now()}`);
+  const decConfig = { ...config, decryption: { symmetricKey: key } };
+  await downloadFile(uploaded.rootHash, out, decConfig);
+  const roundTripped = fs.readFileSync(out, 'utf-8');
+
+  if (roundTripped !== plaintext) {
+    throw new Error(`Round-trip mismatch. Expected "${plaintext}", got "${roundTripped}"`);
+  }
+  console.log('  Plaintext matches after decrypt');
+});
+
+// --- Test 8: Encrypted upload/download — ecies round-trip (encrypt to self) ---
+await test('encrypted (ecies) - upload then download with private key', async () => {
+  if (!config.privateKey) throw new Error('PRIVATE_KEY required for ecies test');
+
+  const plaintext = `ecies round-trip - ${new Date().toISOString()}`;
+  const file = path.join('test-uploads', 'enc-ecies.txt');
+  fs.writeFileSync(file, plaintext);
+
+  const recipientPubKey = pubKeyFromPrivateKey(config.privateKey);
+  const encConfig = { ...config, encryption: { type: 'ecies' as const, recipientPubKey } };
+  const uploaded = await uploadFile(file, encConfig);
+  console.log(`  Root Hash: ${uploaded.rootHash}`);
+
+  const header = await peekHeader(uploaded.rootHash, config);
+  if (header?.version !== 2) {
+    throw new Error(`Expected header v2 (ecies), got ${header?.version ?? 'none'}`);
+  }
+  console.log('  peekHeader detected ecies (v2)');
+
+  const out = path.join('downloads', `enc-ecies-${Date.now()}`);
+  const decConfig = { ...config, decryption: { privateKey: config.privateKey } };
+  await downloadFile(uploaded.rootHash, out, decConfig);
+  const roundTripped = fs.readFileSync(out, 'utf-8');
+
+  if (roundTripped !== plaintext) {
+    throw new Error(`Round-trip mismatch. Expected "${plaintext}", got "${roundTripped}"`);
+  }
+  console.log('  Plaintext matches after decrypt');
+});
+
+// --- Test 9: peekHeader returns null for plaintext file ---
+await test('peekHeader - returns null for plain (unencrypted) file', async () => {
+  if (!uploadedRootHash) throw new Error('Skipped: no plain rootHash available');
+  const header = await peekHeader(uploadedRootHash, config);
+  if (header !== null) {
+    console.log(`  Note: plaintext file first bytes parsed as v${header.version} header.`);
+    console.log('  (peekHeader is best-effort — rare collisions can match a header shape.)');
+  } else {
+    console.log('  Correctly returned null for plaintext file');
   }
 });
 

--- a/scripts/test-sdk-encryption.ts
+++ b/scripts/test-sdk-encryption.ts
@@ -1,0 +1,191 @@
+/**
+ * Direct SDK encryption test — validates the raw Indexer API (no starter kit wrappers).
+ * Documents the exact interfaces from @0gfoundation/0g-ts-sdk for the docs site.
+ *
+ * Usage: npm run tsx scripts/test-sdk-encryption.ts [--network testnet|mainnet]
+ */
+import 'dotenv/config';
+import fs from 'fs';
+import path from 'path';
+import { ZgFile, Indexer, EncryptionHeader } from '@0gfoundation/0g-ts-sdk';
+import type { UploadOption, DownloadOption } from '@0gfoundation/0g-ts-sdk';
+import { ethers } from 'ethers';
+import { getNetwork } from '../src/config.js';
+
+const networkArg = process.argv.indexOf('--network');
+const networkName = networkArg !== -1 ? process.argv[networkArg + 1] : undefined;
+const network = getNetwork(networkName);
+
+if (!process.env.PRIVATE_KEY) {
+    console.error('PRIVATE_KEY not set in .env');
+    process.exit(1);
+}
+
+const provider = new ethers.JsonRpcProvider(network.rpcUrl);
+const signer = new ethers.Wallet(process.env.PRIVATE_KEY, provider);
+const indexer = new Indexer(network.indexerRpc);
+
+let passed = 0;
+let failed = 0;
+
+async function test(name: string, fn: () => Promise<void>) {
+    console.log(`\n--- ${name} ---`);
+    try {
+        await fn();
+        passed++;
+        console.log(`PASS`);
+    } catch (err) {
+        failed++;
+        console.error(`FAIL: ${err instanceof Error ? err.message : err}`);
+    }
+}
+
+console.log('='.repeat(60));
+console.log('Direct SDK Encryption API Tests');
+console.log('='.repeat(60));
+console.log(`Network:  ${network.name} (${network.mode})`);
+console.log(`Indexer:  ${network.indexerRpc}`);
+console.log('='.repeat(60));
+
+// ── Test 1: AES-256 upload + downloadToBlob + decrypt ──────────────────────
+await test('AES-256: upload with UploadOption.encryption, download with DownloadOption.decryption', async () => {
+    const plaintext = `sdk-direct aes256 ${Date.now()}`;
+    const file = path.join('test-uploads', 'sdk-aes256.txt');
+    fs.writeFileSync(file, plaintext);
+
+    // Key generation — SDK has no utility; use Node crypto
+    const key = new Uint8Array(32);
+    crypto.getRandomValues(key);
+
+    const zgFile = await ZgFile.fromFilePath(file);
+
+    // ── Upload with encryption ──────────────────────────────────────────────
+    const uploadOpts: UploadOption = {
+        encryption: { type: 'aes256', key },
+    };
+    const [tx, upErr] = await indexer.upload(zgFile, network.rpcUrl, signer as any, uploadOpts);
+    if (upErr !== null) throw upErr;
+    if (!('rootHash' in tx)) throw new Error('Expected single-file result');
+
+    console.log(`  rootHash: ${tx.rootHash}`);
+    console.log(`  txHash:   ${tx.txHash}`);
+
+    // ── peekHeader — returns [EncryptionHeader | null, Error | null] ────────
+    const [header, peekErr] = await indexer.peekHeader(tx.rootHash);
+    if (peekErr !== null) throw peekErr;
+    if (header === null) throw new Error('Expected encryption header, got null');
+    if (header.version !== 1) throw new Error(`Expected v1, got v${header.version}`);
+    console.log(`  peekHeader: v${header.version} (aes256), ${header.size()} bytes`);
+
+    // ── downloadToBlob with decryption ─────────────────────────────────────
+    const dlOpts: DownloadOption = {
+        proof: true,
+        decryption: { symmetricKey: key },
+    };
+    const [blob, dlErr] = await indexer.downloadToBlob(tx.rootHash, dlOpts);
+    if (dlErr !== null) throw dlErr;
+
+    const result = new TextDecoder().decode(new Uint8Array(await blob.arrayBuffer()));
+    if (result !== plaintext) throw new Error(`Content mismatch: "${result}" !== "${plaintext}"`);
+    console.log(`  Decrypted content matches`);
+});
+
+// ── Test 2: ECIES upload + download ───────────────────────────────────────
+await test('ECIES: upload with recipientPubKey, download with privateKey', async () => {
+    const plaintext = `sdk-direct ecies ${Date.now()}`;
+    const file = path.join('test-uploads', 'sdk-ecies.txt');
+    fs.writeFileSync(file, plaintext);
+
+    // Derive recipient pubkey from wallet (encrypt-to-self pattern)
+    const recipientPubKey = ethers.SigningKey.computePublicKey(
+        signer.signingKey.publicKey,
+        true, // compressed 33-byte key
+    );
+    console.log(`  recipientPubKey: ${recipientPubKey}`);
+
+    const zgFile = await ZgFile.fromFilePath(file);
+
+    // ── Upload ──────────────────────────────────────────────────────────────
+    const uploadOpts: UploadOption = {
+        encryption: { type: 'ecies', recipientPubKey },
+    };
+    const [tx, upErr] = await indexer.upload(zgFile, network.rpcUrl, signer as any, uploadOpts);
+    if (upErr !== null) throw upErr;
+    if (!('rootHash' in tx)) throw new Error('Expected single-file result');
+
+    console.log(`  rootHash: ${tx.rootHash}`);
+
+    // ── peekHeader ─────────────────────────────────────────────────────────
+    const [header, peekErr] = await indexer.peekHeader(tx.rootHash);
+    if (peekErr !== null) throw peekErr;
+    if (header === null) throw new Error('Expected encryption header, got null');
+    if (header.version !== 2) throw new Error(`Expected v2, got v${header.version}`);
+    console.log(`  peekHeader: v${header.version} (ecies), ${header.size()} bytes`);
+
+    // ── downloadToBlob with privateKey ────────────────────────────────────
+    const dlOpts: DownloadOption = {
+        proof: true,
+        decryption: { privateKey: process.env.PRIVATE_KEY },
+    };
+    const [blob, dlErr] = await indexer.downloadToBlob(tx.rootHash, dlOpts);
+    if (dlErr !== null) throw dlErr;
+
+    const result = new TextDecoder().decode(new Uint8Array(await blob.arrayBuffer()));
+    if (result !== plaintext) throw new Error(`Content mismatch: "${result}" !== "${plaintext}"`);
+    console.log(`  Decrypted content matches`);
+});
+
+// ── Test 3: peekHeader returns null for plaintext ─────────────────────────
+await test('peekHeader: returns null for a plaintext file', async () => {
+    const plaintext = `plain text no encryption ${Date.now()}`;
+    const file = path.join('test-uploads', 'sdk-plain.txt');
+    fs.writeFileSync(file, plaintext);
+
+    const zgFile = await ZgFile.fromFilePath(file);
+    const [tx, upErr] = await indexer.upload(zgFile, network.rpcUrl, signer as any);
+    if (upErr !== null) throw upErr;
+    if (!('rootHash' in tx)) throw new Error('Expected single-file result');
+
+    const [header, peekErr] = await indexer.peekHeader(tx.rootHash);
+    if (peekErr !== null) throw peekErr;
+    if (header !== null) {
+        console.log(`  Note: plaintext bytes matched a v${header.version} header shape (best-effort false-positive)`);
+    } else {
+        console.log(`  Correctly returned null for plaintext`);
+    }
+});
+
+// ── Test 4: wrong key returns raw ciphertext (does not throw) ─────────────
+await test('AES-256: wrong key silently returns raw ciphertext (best-effort)', async () => {
+    const plaintext = `sdk wrong-key test ${Date.now()}`;
+    const file = path.join('test-uploads', 'sdk-wrongkey.txt');
+    fs.writeFileSync(file, plaintext);
+
+    const correctKey = new Uint8Array(32);
+    crypto.getRandomValues(correctKey);
+    const wrongKey = new Uint8Array(32); // all zeros
+
+    const zgFile = await ZgFile.fromFilePath(file);
+    const [tx, upErr] = await indexer.upload(
+        zgFile, network.rpcUrl, signer as any,
+        { encryption: { type: 'aes256', key: correctKey } },
+    );
+    if (upErr !== null) throw upErr;
+    if (!('rootHash' in tx)) throw new Error('Expected single-file result');
+
+    const [blob, dlErr] = await indexer.downloadToBlob(tx.rootHash, {
+        decryption: { symmetricKey: wrongKey },
+    });
+    if (dlErr !== null) throw dlErr;
+
+    const bytes = new Uint8Array(await blob.arrayBuffer());
+    const result = new TextDecoder().decode(bytes);
+    if (result === plaintext) throw new Error('Wrong key returned plaintext — unexpected');
+    console.log(`  Returned ${bytes.length} bytes of raw/garbage data (did not throw)`);
+});
+
+// ── Summary ───────────────────────────────────────────────────────────────
+console.log('\n' + '='.repeat(60));
+console.log(`Results: ${passed} passed, ${failed} failed out of ${passed + failed} tests`);
+console.log('='.repeat(60));
+if (failed > 0) process.exit(1);

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,6 +16,15 @@ export interface NetworkConfig {
   explorerUrl: string;
 }
 
+export type EncryptionConfig =
+  | { type: 'aes256'; key: Uint8Array }
+  | { type: 'ecies'; recipientPubKey: Uint8Array | string };
+
+export interface DecryptionConfig {
+  symmetricKey?: Uint8Array | string;
+  privateKey?: Uint8Array | string;
+}
+
 export interface AppConfig {
   network: NetworkConfig;
   privateKey?: string;
@@ -23,6 +32,8 @@ export interface AppConfig {
   gasLimit?: bigint;
   maxRetries?: number;
   maxGasPrice?: bigint;
+  encryption?: EncryptionConfig;
+  decryption?: DecryptionConfig;
 }
 
 // Indexer URLs per network and mode
@@ -71,11 +82,15 @@ export function getNetwork(name?: string, mode?: string): NetworkConfig {
   };
 }
 
-export function getConfig(overrides?: {
+export interface ConfigOverrides {
   network?: string;
   mode?: string;
   privateKey?: string;
-}): AppConfig {
+  encryption?: EncryptionConfig;
+  decryption?: DecryptionConfig;
+}
+
+export function getConfig(overrides?: ConfigOverrides): AppConfig {
   const network = getNetwork(overrides?.network, overrides?.mode);
   const privateKey = overrides?.privateKey || process.env.PRIVATE_KEY;
 
@@ -86,6 +101,61 @@ export function getConfig(overrides?: {
     gasLimit: process.env.GAS_LIMIT ? BigInt(process.env.GAS_LIMIT) : undefined,
     maxRetries: process.env.MAX_RETRIES ? parseInt(process.env.MAX_RETRIES) : undefined,
     maxGasPrice: process.env.MAX_GAS_PRICE ? BigInt(process.env.MAX_GAS_PRICE) : undefined,
+    encryption: overrides?.encryption ?? encryptionFromEnv(),
+    decryption: overrides?.decryption ?? decryptionFromEnv(),
+  };
+}
+
+// --- Encryption helpers ---------------------------------------------------
+
+/** Parse a 0x-prefixed or bare hex string into bytes. */
+export function hexToBytes(hex: string): Uint8Array {
+  const s = hex.startsWith('0x') || hex.startsWith('0X') ? hex.slice(2) : hex;
+  if (s.length % 2 !== 0 || !/^[0-9a-fA-F]*$/.test(s)) {
+    throw new Error(`Invalid hex string: "${hex}"`);
+  }
+  const out = new Uint8Array(s.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(s.substr(i * 2, 2), 16);
+  }
+  return out;
+}
+
+/** Generate a cryptographically random 32-byte AES-256 key. */
+export function generateAes256Key(): Uint8Array {
+  return ethers.randomBytes(32);
+}
+
+/** Derive the secp256k1 public key (0x-prefixed compressed, 33 bytes) from a private key. */
+export function pubKeyFromPrivateKey(privateKey: string): string {
+  const wallet = new ethers.Wallet(privateKey);
+  // ethers.SigningKey.computePublicKey returns uncompressed by default; pass true for compressed.
+  return ethers.SigningKey.computePublicKey(wallet.signingKey.publicKey, true);
+}
+
+function encryptionFromEnv(): EncryptionConfig | undefined {
+  const mode = process.env.ENCRYPTION_MODE?.toLowerCase();
+  if (!mode) return undefined;
+  if (mode === 'aes256') {
+    const key = process.env.ENCRYPTION_KEY;
+    if (!key) throw new Error('ENCRYPTION_MODE=aes256 requires ENCRYPTION_KEY in env');
+    return { type: 'aes256', key: hexToBytes(key) };
+  }
+  if (mode === 'ecies') {
+    const pub = process.env.RECIPIENT_PUBKEY;
+    if (!pub) throw new Error('ENCRYPTION_MODE=ecies requires RECIPIENT_PUBKEY in env');
+    return { type: 'ecies', recipientPubKey: pub };
+  }
+  throw new Error(`Invalid ENCRYPTION_MODE: "${mode}". Use "aes256" or "ecies".`);
+}
+
+function decryptionFromEnv(): DecryptionConfig | undefined {
+  const sym = process.env.DECRYPTION_KEY;
+  const priv = process.env.RECIPIENT_PRIVKEY;
+  if (!sym && !priv) return undefined;
+  return {
+    symmetricKey: sym,
+    privateKey: priv,
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export {
   downloadFile,
   uploadData,
   batchUpload,
+  peekHeader,
   StorageError,
   UploadError,
   DownloadError,
@@ -17,7 +18,22 @@ export {
   getNetwork,
   createSigner,
   createIndexer,
+  hexToBytes,
+  generateAes256Key,
+  pubKeyFromPrivateKey,
   NETWORKS,
 } from './config.js';
 
-export type { NetworkName, NetworkConfig, AppConfig, StorageMode } from './config.js';
+export type {
+  NetworkName,
+  NetworkConfig,
+  AppConfig,
+  StorageMode,
+  EncryptionConfig,
+  DecryptionConfig,
+  ConfigOverrides,
+} from './config.js';
+
+// Re-export SDK encryption types for library consumers
+export type { EncryptionOption } from '@0gfoundation/0g-ts-sdk';
+export { EncryptionHeader } from '@0gfoundation/0g-ts-sdk';

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,8 +1,15 @@
-import { ZgFile, Indexer, MemData } from '@0gfoundation/0g-ts-sdk';
+import { ZgFile, Indexer, MemData, EncryptionHeader } from '@0gfoundation/0g-ts-sdk';
+import type { UploadOption, EncryptionOption } from '@0gfoundation/0g-ts-sdk';
 import { ethers } from 'ethers';
 import fs from 'fs';
 import path from 'path';
-import { AppConfig, createSigner, createIndexer } from './config.js';
+import {
+  AppConfig,
+  EncryptionConfig,
+  DecryptionConfig,
+  createSigner,
+  createIndexer,
+} from './config.js';
 
 interface RetryOpts {
   Retries: number;
@@ -75,6 +82,15 @@ function buildTxOpts(config: AppConfig) {
   return Object.keys(opts).length > 0 ? opts : undefined;
 }
 
+function buildUploadOpts(enc?: EncryptionConfig): UploadOption | undefined {
+  if (!enc) return undefined;
+  const encryption: EncryptionOption =
+    enc.type === 'aes256'
+      ? { type: 'aes256', key: enc.key }
+      : { type: 'ecies', recipientPubKey: enc.recipientPubKey };
+  return { encryption };
+}
+
 // --- Core Functions ---
 
 /**
@@ -103,7 +119,7 @@ export async function uploadFile(
       zgFile,
       config.network.rpcUrl,
       signer as any, // ethers ESM/CJS type mismatch — runtime compatible
-      undefined,
+      buildUploadOpts(config.encryption),
       buildRetryOpts(config),
       buildTxOpts(config),
     );
@@ -128,6 +144,10 @@ export async function uploadFile(
 
 /**
  * Download a file from 0G Storage by its root hash.
+ *
+ * When `config.decryption` is set, downloads via `downloadToBlob` and runs the
+ * SDK's best-effort decrypt (symmetric or ECIES). Otherwise streams to disk
+ * with the Node-only `indexer.download()` path, which is better for large files.
  */
 export async function downloadFile(
   rootHash: string,
@@ -142,13 +162,50 @@ export async function downloadFile(
   }
 
   const indexer = createIndexer(config);
-  const err = await indexer.download(rootHash, resolvedOutput, true);
 
+  if (config.decryption) {
+    const [blob, err] = await indexer.downloadToBlob(rootHash, {
+      proof: true,
+      decryption: normalizeDecryption(config.decryption),
+    });
+    if (err !== null) {
+      throw new DownloadError(`Download failed: ${err}`);
+    }
+    const bytes = new Uint8Array(await blob.arrayBuffer());
+    fs.writeFileSync(resolvedOutput, bytes);
+    return { outputPath: resolvedOutput };
+  }
+
+  const err = await indexer.download(rootHash, resolvedOutput, true);
   if (err !== null) {
     throw new DownloadError(`Download failed: ${err}`);
   }
 
   return { outputPath: resolvedOutput };
+}
+
+function normalizeDecryption(d: DecryptionConfig) {
+  return {
+    symmetricKey: d.symmetricKey,
+    privateKey: d.privateKey,
+  };
+}
+
+/**
+ * Peek the encryption header of a stored file without downloading the body.
+ * Returns null if the file is not encrypted (or the header is malformed).
+ */
+export async function peekHeader(
+  rootHash: string,
+  config: AppConfig,
+): Promise<EncryptionHeader | null> {
+  validateRootHash(rootHash);
+  const indexer = createIndexer(config);
+  const [header, err] = await indexer.peekHeader(rootHash);
+  if (err !== null) {
+    throw new DownloadError(`peekHeader failed: ${err}`);
+  }
+  return header;
 }
 
 /**
@@ -177,7 +234,7 @@ export async function uploadData(
     memData,
     config.network.rpcUrl,
     signer as any, // ethers ESM/CJS type mismatch — runtime compatible
-    undefined,
+    buildUploadOpts(config.encryption),
     buildRetryOpts(config),
     buildTxOpts(config),
   );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,5 @@
     "declarationMap": true
   },
   "include": ["src/**/*", "scripts/**/*"],
-  "exclude": ["node_modules", "dist", "web"]
+  "exclude": ["node_modules", "dist", "web", "src/test-sdk.ts"]
 }

--- a/web/index.html
+++ b/web/index.html
@@ -57,6 +57,33 @@
           <span id="file-size"></span>
           <button id="clear-file" class="btn btn-small">Clear</button>
         </div>
+        <div class="encryption-panel">
+          <label class="checkbox-row">
+            <input type="checkbox" id="encrypt-toggle" />
+            <span>Encrypt before upload</span>
+          </label>
+          <div id="encrypt-options" class="encrypt-options hidden">
+            <div class="input-group">
+              <label for="encrypt-mode">Mode</label>
+              <select id="encrypt-mode">
+                <option value="aes256">AES-256 (symmetric)</option>
+                <option value="ecies">ECIES (to recipient pubkey)</option>
+              </select>
+            </div>
+            <div id="aes-key-row" class="input-group">
+              <label for="encrypt-key">AES key (64 hex, optional)</label>
+              <div class="row-flex">
+                <input type="text" id="encrypt-key" placeholder="0x... (leave blank to generate)" spellcheck="false" />
+                <button id="encrypt-gen-key" class="btn btn-small" type="button">Generate</button>
+              </div>
+            </div>
+            <div id="ecies-pub-row" class="input-group hidden">
+              <label for="encrypt-recipient">Recipient compressed secp256k1 pubkey</label>
+              <input type="text" id="encrypt-recipient" placeholder="0x02... (33 bytes / 66 hex)" spellcheck="false" />
+            </div>
+          </div>
+        </div>
+
         <button id="upload-btn" class="btn btn-primary btn-full" disabled>
           Upload to 0G Storage
         </button>
@@ -75,6 +102,14 @@
               <a id="result-tx-link" target="_blank" rel="noopener"></a>
             </div>
           </div>
+          <div id="result-enc-key-row" class="result-row hidden">
+            <label>Decryption key</label>
+            <div class="result-value">
+              <code id="result-enc-key"></code>
+              <button id="copy-enc-key" class="btn btn-small">Copy</button>
+            </div>
+            <p class="warn-text">Save this key — without it the file is unrecoverable.</p>
+          </div>
         </div>
       </section>
 
@@ -88,6 +123,23 @@
             spellcheck="false"
           />
         </div>
+
+        <div id="peek-info" class="peek-info hidden"></div>
+
+        <div id="decrypt-options" class="encrypt-options hidden">
+          <div id="decrypt-aes-row" class="input-group">
+            <label for="decrypt-key">AES-256 key (64 hex)</label>
+            <input type="text" id="decrypt-key" placeholder="0x..." spellcheck="false" />
+          </div>
+          <div id="decrypt-ecies-row" class="input-group hidden">
+            <label for="decrypt-privkey">Private key (secp256k1) &mdash; stays in your browser</label>
+            <input type="text" id="decrypt-privkey" placeholder="0x..." spellcheck="false" />
+            <p class="warn-text">
+              Pasting a private key into a web UI is risky. Only use this with keys you do not use for funds.
+            </p>
+          </div>
+        </div>
+
         <button id="download-btn" class="btn btn-primary btn-full" disabled>
           Download from 0G Storage
         </button>

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,7 +8,7 @@
       "name": "0g-storage-web",
       "version": "1.0.0",
       "dependencies": {
-        "@0gfoundation/0g-ts-sdk": "^1.2.1",
+        "@0gfoundation/0g-ts-sdk": "^1.2.6",
         "ethers": "^6.13.1"
       },
       "devDependencies": {
@@ -18,17 +18,47 @@
       }
     },
     "node_modules/@0gfoundation/0g-ts-sdk": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@0gfoundation/0g-ts-sdk/-/0g-ts-sdk-1.2.1.tgz",
-      "integrity": "sha512-1PBq+aug6p3OYh9UbEDxn+mroQ4XCjd7355wwStfd8ykyKMXHTdrSuNrfranr5TnF/uksKUWnN3HJ73gYKKDpw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@0gfoundation/0g-ts-sdk/-/0g-ts-sdk-1.2.6.tgz",
+      "integrity": "sha512-1CXUnMblQOVJek+T7l+DRn1KuzPmZV6JfMrZbXOihSAPF2er8vFkq519MqoJroUH2yEjdW1z41x5aVPbCSp1gQ==",
       "license": "ISC",
       "dependencies": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/keccak256": "^5.7.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "^1.9.7",
+        "@noble/hashes": "^1.8.0",
         "open-jsonrpc-provider": "^0.2.1"
       },
       "peerDependencies": {
         "ethers": "6.13.1"
+      }
+    },
+    "node_modules/@0gfoundation/0g-ts-sdk/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@0gfoundation/0g-ts-sdk/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@adraffy/ens-normalize": {
@@ -489,6 +519,18 @@
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@noble/curves": {
       "version": "1.2.0",

--- a/web/package.json
+++ b/web/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@0gfoundation/0g-ts-sdk": "^1.2.1",
+    "@0gfoundation/0g-ts-sdk": "^1.2.6",
     "ethers": "^6.13.1"
   },
   "devDependencies": {

--- a/web/src/storage.ts
+++ b/web/src/storage.ts
@@ -1,10 +1,56 @@
-import { Blob as ZgBlob, Indexer, StorageNode } from '@0gfoundation/0g-ts-sdk';
+import {
+  Blob as ZgBlob,
+  Indexer,
+  StorageNode,
+  EncryptionHeader,
+  tryDecrypt,
+} from '@0gfoundation/0g-ts-sdk';
+import type { UploadOption, EncryptionOption } from '@0gfoundation/0g-ts-sdk';
 import { ethers } from 'ethers';
 import type { NetworkConfig } from './config.js';
 
 const DEFAULT_CHUNK_SIZE = 256;
 const DEFAULT_SEGMENT_MAX_CHUNKS = 1024;
 const ROOT_HASH_REGEX = /^0x[0-9a-fA-F]{64}$/;
+
+export type EncryptionInput =
+  | { type: 'aes256'; key: Uint8Array }
+  | { type: 'ecies'; recipientPubKey: Uint8Array | string };
+
+export interface DecryptionInput {
+  symmetricKey?: Uint8Array | string;
+  privateKey?: Uint8Array | string;
+}
+
+function toSdkEncryption(e: EncryptionInput): EncryptionOption {
+  return e.type === 'aes256'
+    ? { type: 'aes256', key: e.key }
+    : { type: 'ecies', recipientPubKey: e.recipientPubKey };
+}
+
+/** Parse 0x-prefixed or bare hex into bytes. */
+export function hexToBytes(hex: string): Uint8Array {
+  const s = hex.startsWith('0x') || hex.startsWith('0X') ? hex.slice(2) : hex;
+  if (s.length % 2 !== 0 || !/^[0-9a-fA-F]*$/.test(s)) {
+    throw new Error(`Invalid hex string: "${hex}"`);
+  }
+  const out = new Uint8Array(s.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(s.substr(i * 2, 2), 16);
+  }
+  return out;
+}
+
+export function bytesToHex(bytes: Uint8Array): string {
+  return '0x' + Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join('');
+}
+
+/** Generate a random 32-byte AES-256 key using the browser WebCrypto API. */
+export function generateAes256Key(): Uint8Array {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return bytes;
+}
 
 /** Mirrors SDK's GetSplitNum: ceil division */
 function getSplitNum(total: number, unit: number): number {
@@ -24,14 +70,16 @@ export interface DownloadResult {
 
 /**
  * Upload a browser File to 0G Storage.
+ * Pass `encryption` to encrypt client-side before upload (SDK 1.2.2+).
  */
 export async function uploadFile(
   file: File,
   network: NetworkConfig,
   signer: ethers.Signer,
   onStatus?: (msg: string) => void,
+  encryption?: EncryptionInput,
 ): Promise<UploadResult> {
-  onStatus?.('Preparing file...');
+  onStatus?.(encryption ? `Preparing file (${encryption.type} encrypt)...` : 'Preparing file...');
 
   const zgBlob = new ZgBlob(file);
   const indexer = new Indexer(network.indexerRpc);
@@ -43,10 +91,15 @@ export async function uploadFile(
 
   onStatus?.('Uploading to 0G Storage...');
 
+  const uploadOpts: UploadOption | undefined = encryption
+    ? { encryption: toSdkEncryption(encryption) }
+    : undefined;
+
   const [tx, uploadErr] = await indexer.upload(
     zgBlob,
     network.rpcUrl,
     signer as ethers.Signer,
+    uploadOpts,
   );
 
   if (uploadErr !== null) {
@@ -73,6 +126,7 @@ export async function downloadFile(
   rootHash: string,
   network: NetworkConfig,
   onStatus?: (msg: string, percent?: number) => void,
+  decryption?: DecryptionInput,
 ): Promise<DownloadResult> {
   if (!ROOT_HASH_REGEX.test(rootHash)) {
     throw new Error('Invalid root hash format. Expected 0x followed by 64 hex characters.');
@@ -92,16 +146,17 @@ export async function downloadFile(
   const nodes: StorageNode[] = locations.map(loc => new StorageNode(loc.url));
 
   // Get file info from the first responsive node
-  let fileInfo: {
+  type FileInfoShape = {
     tx: { size: number; seq: number; startEntryIndex: number };
     finalized: boolean;
-  } | null = null;
+  };
+  let fileInfo: FileInfoShape | null = null;
 
   for (const node of nodes) {
     try {
       const info = await node.getFileInfo(rootHash, true);
       if (info) {
-        fileInfo = info as typeof fileInfo;
+        fileInfo = info as unknown as FileInfoShape;
         break;
       }
     } catch {
@@ -109,7 +164,7 @@ export async function downloadFile(
     }
   }
 
-  if (!fileInfo) {
+  if (fileInfo === null) {
     throw new Error('Could not retrieve file info from any storage node');
   }
 
@@ -176,12 +231,53 @@ export async function downloadFile(
 
   onStatus?.('Download complete!', 100);
 
-  const blob = new Blob(segments as BlobPart[]);
+  let outBlob = new Blob(segments as BlobPart[]);
+  let outSize = fileSize;
+
+  if (decryption) {
+    onStatus?.('Decrypting...', 100);
+    const cipher = new Uint8Array(await outBlob.arrayBuffer());
+    const symmetricKey =
+      typeof decryption.symmetricKey === 'string'
+        ? hexToBytes(decryption.symmetricKey)
+        : decryption.symmetricKey;
+    const privateKey =
+      typeof decryption.privateKey === 'string' && decryption.privateKey.startsWith('0x')
+        ? decryption.privateKey.slice(2)
+        : decryption.privateKey;
+    const { bytes, decrypted } = tryDecrypt(cipher, { symmetricKey, privateKey });
+    if (!decrypted) {
+      throw new Error(
+        'Decryption failed. Check that the supplied key matches the file’s encryption mode.',
+      );
+    }
+    outBlob = new Blob([bytes as BlobPart]);
+    outSize = bytes.length;
+    onStatus?.('Decrypted.', 100);
+  }
+
   return {
-    blob,
+    blob: outBlob,
     filename: rootHash,
-    size: fileSize,
+    size: outSize,
   };
+}
+
+/**
+ * Peek at a file's first bytes to determine if it is encrypted.
+ * Uses the SDK's Indexer.peekHeader (browser-safe).
+ */
+export async function peekEncryptionHeader(
+  rootHash: string,
+  network: NetworkConfig,
+): Promise<EncryptionHeader | null> {
+  if (!ROOT_HASH_REGEX.test(rootHash)) {
+    throw new Error('Invalid root hash format. Expected 0x followed by 64 hex characters.');
+  }
+  const indexer = new Indexer(network.indexerRpc);
+  const [header, err] = await indexer.peekHeader(rootHash);
+  if (err !== null) throw err;
+  return header;
 }
 
 /**

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -401,3 +401,67 @@ footer a:hover {
     padding: 20px;
   }
 }
+
+/* Encryption panel */
+.encryption-panel {
+  margin: 16px 0;
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface-hover);
+}
+.checkbox-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  user-select: none;
+}
+.checkbox-row input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--primary);
+}
+.encrypt-options {
+  margin-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.encrypt-options .input-group label {
+  display: block;
+  margin-bottom: 4px;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+.encrypt-options input[type="text"],
+.encrypt-options select {
+  width: 100%;
+  padding: 8px 10px;
+  background: var(--surface);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 13px;
+}
+.row-flex {
+  display: flex;
+  gap: 8px;
+}
+.row-flex input {
+  flex: 1;
+}
+.warn-text {
+  margin-top: 6px;
+  color: var(--warning);
+  font-size: 12px;
+}
+.peek-info {
+  margin: 10px 0;
+  padding: 8px 12px;
+  border-radius: var(--radius-sm);
+  background: rgba(99, 102, 241, 0.12);
+  color: var(--text);
+  font-size: 13px;
+}

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -12,6 +12,12 @@ import {
   uploadFile,
   downloadFile,
   saveBlobAsFile,
+  peekEncryptionHeader,
+  generateAes256Key,
+  hexToBytes,
+  bytesToHex,
+  type EncryptionInput,
+  type DecryptionInput,
 } from './storage.js';
 
 // --- State ---
@@ -52,6 +58,29 @@ const downloadBtn = $<HTMLButtonElement>('download-btn');
 const downloadStatus = $<HTMLDivElement>('download-status');
 const downloadResult = $<HTMLDivElement>('download-result');
 const downloadCompleteMsg = $<HTMLParagraphElement>('download-complete-msg');
+
+// --- Encryption DOM ---
+const encryptToggle = $<HTMLInputElement>('encrypt-toggle');
+const encryptOptions = $<HTMLDivElement>('encrypt-options');
+const encryptMode = $<HTMLSelectElement>('encrypt-mode');
+const aesKeyRow = $<HTMLDivElement>('aes-key-row');
+const encryptKey = $<HTMLInputElement>('encrypt-key');
+const encryptGenKey = $<HTMLButtonElement>('encrypt-gen-key');
+const eciesPubRow = $<HTMLDivElement>('ecies-pub-row');
+const encryptRecipient = $<HTMLInputElement>('encrypt-recipient');
+const resultEncKeyRow = $<HTMLDivElement>('result-enc-key-row');
+const resultEncKey = $<HTMLElement>('result-enc-key');
+const copyEncKeyBtn = $<HTMLButtonElement>('copy-enc-key');
+
+// --- Decryption DOM ---
+const peekInfo = $<HTMLDivElement>('peek-info');
+const decryptOptions = $<HTMLDivElement>('decrypt-options');
+const decryptAesRow = $<HTMLDivElement>('decrypt-aes-row');
+const decryptKey = $<HTMLInputElement>('decrypt-key');
+const decryptEciesRow = $<HTMLDivElement>('decrypt-ecies-row');
+const decryptPrivkey = $<HTMLInputElement>('decrypt-privkey');
+
+let peekedHeaderVersion: number | null = null; // 1 = aes256, 2 = ecies, null = none
 
 // --- Helpers ---
 function truncateAddress(addr: string): string {
@@ -164,6 +193,108 @@ function handleClearFile() {
   updateButtonStates();
 }
 
+// --- Encryption helpers ---
+function handleEncryptToggle() {
+  encryptOptions.classList.toggle('hidden', !encryptToggle.checked);
+}
+
+function handleEncryptModeChange() {
+  const mode = encryptMode.value;
+  aesKeyRow.classList.toggle('hidden', mode !== 'aes256');
+  eciesPubRow.classList.toggle('hidden', mode !== 'ecies');
+}
+
+function handleGenerateKey() {
+  encryptKey.value = bytesToHex(generateAes256Key());
+}
+
+/** Build encryption input from UI state. Returns undefined if toggle is off. */
+function readEncryptionInput(): { enc: EncryptionInput; displayKey?: string } | undefined {
+  if (!encryptToggle.checked) return undefined;
+
+  if (encryptMode.value === 'aes256') {
+    let key: Uint8Array;
+    let keyHex: string;
+    const raw = encryptKey.value.trim();
+    if (raw === '') {
+      key = generateAes256Key();
+      keyHex = bytesToHex(key);
+      encryptKey.value = keyHex;
+    } else {
+      key = hexToBytes(raw);
+      keyHex = raw;
+      if (key.length !== 32) {
+        throw new Error(`AES-256 key must be 32 bytes (64 hex chars). Got ${key.length}.`);
+      }
+    }
+    return { enc: { type: 'aes256', key }, displayKey: keyHex };
+  }
+
+  const recipient = encryptRecipient.value.trim();
+  if (!recipient) {
+    throw new Error('Recipient public key is required for ECIES encryption.');
+  }
+  return { enc: { type: 'ecies', recipientPubKey: recipient } };
+}
+
+/** Build decryption input from UI state. Returns undefined if nothing to decrypt. */
+function readDecryptionInput(): DecryptionInput | undefined {
+  if (peekedHeaderVersion === null) return undefined;
+
+  if (peekedHeaderVersion === 1) {
+    const hex = decryptKey.value.trim();
+    if (!hex) throw new Error('File is encrypted (AES-256). Enter the decryption key.');
+    return { symmetricKey: hex };
+  }
+  if (peekedHeaderVersion === 2) {
+    const hex = decryptPrivkey.value.trim();
+    if (!hex) throw new Error('File is encrypted (ECIES). Enter your private key.');
+    return { privateKey: hex };
+  }
+  return undefined;
+}
+
+function updateDecryptPanel() {
+  if (peekedHeaderVersion === null) {
+    decryptOptions.classList.add('hidden');
+    peekInfo.classList.add('hidden');
+    return;
+  }
+  decryptOptions.classList.remove('hidden');
+  decryptAesRow.classList.toggle('hidden', peekedHeaderVersion !== 1);
+  decryptEciesRow.classList.toggle('hidden', peekedHeaderVersion !== 2);
+}
+
+async function handlePeekForDownload() {
+  const rootHash = downloadHash.value.trim();
+  if (!/^0x[0-9a-fA-F]{64}$/.test(rootHash)) {
+    peekedHeaderVersion = null;
+    updateDecryptPanel();
+    updateButtonStates();
+    return;
+  }
+
+  try {
+    const header = await peekEncryptionHeader(rootHash, currentNetwork);
+    if (header === null) {
+      peekedHeaderVersion = null;
+      peekInfo.textContent = 'No encryption header detected — file is plaintext.';
+      peekInfo.classList.remove('hidden');
+    } else {
+      peekedHeaderVersion = header.version;
+      const kind = header.version === 1 ? 'AES-256 (symmetric)' : `ECIES (asymmetric, v${header.version})`;
+      peekInfo.textContent = `Encrypted: ${kind}. Enter the matching key below to decrypt.`;
+      peekInfo.classList.remove('hidden');
+    }
+  } catch {
+    // Peek is best-effort — ignore failures and let the download proceed raw.
+    peekedHeaderVersion = null;
+    peekInfo.classList.add('hidden');
+  }
+  updateDecryptPanel();
+  updateButtonStates();
+}
+
 // --- Upload ---
 async function handleUpload() {
   if (!selectedFile || !isConnected) return;
@@ -173,12 +304,20 @@ async function handleUpload() {
 
   uploadBtn.disabled = true;
   uploadResult.classList.add('hidden');
+  resultEncKeyRow.classList.add('hidden');
 
   try {
+    const encInput = readEncryptionInput();
     const networkLabel = `${currentNetwork.name} (${currentNetwork.mode})`;
-    const result = await uploadFile(selectedFile, currentNetwork, signer, (msg) => {
-      showStatus(uploadStatus, `[${networkLabel}] ${msg}`, 'loading');
-    });
+    const result = await uploadFile(
+      selectedFile,
+      currentNetwork,
+      signer,
+      (msg) => {
+        showStatus(uploadStatus, `[${networkLabel}] ${msg}`, 'loading');
+      },
+      encInput?.enc,
+    );
 
     showStatus(uploadStatus, `Upload successful on ${networkLabel}!`, 'success');
 
@@ -186,6 +325,11 @@ async function handleUpload() {
     resultTxLink.textContent = `${result.txHash.slice(0, 16)}...`;
     resultTxLink.href = `${currentNetwork.explorerUrl}/tx/${result.txHash}`;
     uploadResult.classList.remove('hidden');
+
+    if (encInput?.displayKey) {
+      resultEncKey.textContent = encInput.displayKey;
+      resultEncKeyRow.classList.remove('hidden');
+    }
   } catch (err: any) {
     showStatus(uploadStatus, `Upload failed: ${err.message}`, 'error');
   } finally {
@@ -203,10 +347,16 @@ async function handleDownload() {
   downloadResult.classList.add('hidden');
 
   try {
+    const decryption = readDecryptionInput();
     const networkLabel = `${currentNetwork.name} (${currentNetwork.mode})`;
-    const result = await downloadFile(rootHash, currentNetwork, (msg) => {
-      showStatus(downloadStatus, `[${networkLabel}] ${msg}`, 'loading');
-    });
+    const result = await downloadFile(
+      rootHash,
+      currentNetwork,
+      (msg) => {
+        showStatus(downloadStatus, `[${networkLabel}] ${msg}`, 'loading');
+      },
+      decryption,
+    );
 
     showStatus(downloadStatus, `Download complete from ${networkLabel}!`, 'success');
     downloadCompleteMsg.textContent = `File downloaded: ${formatBytes(result.size)}`;
@@ -224,7 +374,13 @@ async function handleDownload() {
 // --- Init ---
 export function initUI(hasMetaMask: boolean) {
   // Download always works (no wallet needed)
-  downloadHash.addEventListener('input', updateButtonStates);
+  downloadHash.addEventListener('input', () => {
+    peekedHeaderVersion = null;
+    peekInfo.classList.add('hidden');
+    decryptOptions.classList.add('hidden');
+    updateButtonStates();
+  });
+  downloadHash.addEventListener('blur', handlePeekForDownload);
   downloadBtn.addEventListener('click', handleDownload);
 
   // Mode selector always works (affects which indexer is used for download)
@@ -237,6 +393,15 @@ export function initUI(hasMetaMask: boolean) {
       navigator.clipboard.writeText(hash);
       copyHashBtn.textContent = 'Copied!';
       setTimeout(() => { copyHashBtn.textContent = 'Copy'; }, 1500);
+    }
+  });
+
+  copyEncKeyBtn.addEventListener('click', () => {
+    const key = resultEncKey.textContent;
+    if (key) {
+      navigator.clipboard.writeText(key);
+      copyEncKeyBtn.textContent = 'Copied!';
+      setTimeout(() => { copyEncKeyBtn.textContent = 'Copy'; }, 1500);
     }
   });
 
@@ -273,6 +438,11 @@ export function initUI(hasMetaMask: boolean) {
     dropZone.classList.remove('dragover');
     if (e.dataTransfer?.files?.[0]) handleFileSelect(e.dataTransfer.files[0]);
   });
+
+  // Encryption toggle + controls
+  encryptToggle.addEventListener('change', handleEncryptToggle);
+  encryptMode.addEventListener('change', handleEncryptModeChange);
+  encryptGenKey.addEventListener('click', handleGenerateKey);
 
   // Upload
   uploadBtn.addEventListener('click', handleUpload);


### PR DESCRIPTION
## Summary

- Bumps `@0gfoundation/0g-ts-sdk` from `^1.2.1` → `^1.2.6` to pick up the new client-side encryption APIs.
- Adds **dedicated encrypted examples** (`encrypted-upload`, `encrypted-download`, `peek`) alongside the existing **plain** scripts so the starter kit clearly documents both with and without encryption.
- Extends the library, the web UI, and the docs end-to-end. Existing plain flows are unchanged.

## What's new

### Library (`src/`)
- `AppConfig.encryption` (`aes256` | `ecies`) and `AppConfig.decryption` (`symmetricKey`/`privateKey`), parsed from env or passed to `getConfig()`.
- `uploadFile` / `uploadData` now forward `{ encryption }` as `UploadOption`.
- `downloadFile` routes through `indexer.downloadToBlob({ decryption })` when a key is supplied (the Node `indexer.download()` has no decryption option), and keeps the streaming path for plain downloads.
- New helpers: `peekHeader()`, `generateAes256Key()`, `pubKeyFromPrivateKey()`, `hexToBytes()`.
- Re-exports `EncryptionOption` and `EncryptionHeader` from the SDK for consumers.

### CLI scripts
| Script | Purpose |
| --- | --- |
| `npm run upload` / `download` | **Unchanged** — the "without encryption" reference path. |
| `npm run upload:encrypted` | `--mode aes256\|ecies`, auto-generates AES key, prints it with a "save this" warning, defaults ECIES recipient to self. |
| `npm run download:encrypted` | Peeks the header first, warns if the supplied key type mismatches the detected mode. |
| `npm run peek` | Inspects the encryption header without downloading the file body. |

`scripts/test-all.ts` adds AES-256 and ECIES round-trip tests plus a `peekHeader` null check on a plaintext file.

### Web UI
- Upload: "Encrypt before upload" toggle → mode selector + key input with a Generate button. Shows (and lets the user copy) the AES key after upload.
- Download: auto-peeks the header on hash blur, reveals the correct key input (AES or ECIES) with a warning banner about pasting private keys into a browser.
- Uses `indexer.peekHeader` + SDK `tryDecrypt` directly so the existing browser-safe download algorithm is preserved.

### Docs
- `README.md`: new **Encryption** section with plain / AES-256 / ECIES recipes, library usage, env-var configuration, and gotchas.
- `.env.example`: `ENCRYPTION_MODE`, `ENCRYPTION_KEY`, `RECIPIENT_PUBKEY`, `DECRYPTION_KEY`, `RECIPIENT_PRIVKEY`.

### Misc
- `tsconfig.json` excludes the unreferenced legacy `src/test-sdk.ts` that still imports the old `@0glabs` scope and was blocking `tsc`. Unrelated to encryption, but necessary for a green build.

## Test plan

- [x] `npm run build` — root project compiles
- [x] `npm run web:build` — web bundle compiles (Vite)
- [x] `--help` output on all three new scripts
- [ ] `npm run test:all` end-to-end on testnet (requires `PRIVATE_KEY` — skipped in CI/sandbox)
- [ ] Manual browser smoke test of encrypt upload → peek → decrypt download
- [ ] Try AES-256 round-trip with a user-supplied key
- [ ] Try ECIES encrypt-to-self with wallet's own keypair

https://claude.ai/code/session_01AqLwRoWhiPvUT8ZAAu4no9

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqLwRoWhiPvUT8ZAAu4no9)_